### PR TITLE
Tutoriel Pelican: update publishconf.py to force https

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'tutoriel-pelican.jn-blog.com'
+SITEURL = 'https://tutoriel-pelican.jn-blog.com'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
In order to load statics, the SITEURL variable has to indicate the https protocole